### PR TITLE
Default to latest fappcli release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# install fappcli action for Github Actions
+# Install fappcli action for Github Actions
 An action for Github Action that installs the FApp CLI tool to make Axis ACAP development and CI/CD easier.
 
 This tool can be used to build ACAP applications, inspect/verify `.eap` package files and create new applications from templates.
@@ -6,3 +6,12 @@ This tool can be used to build ACAP applications, inspect/verify `.eap` package 
 For use in GitHub Actions, see also:
 * [build-eap-action](https://github.com/fixedit-ai/build-eap-action)
 * [test-eap-action](https://github.com/fixedit-ai/test-eap-action)
+
+If no version of fappcli is specified, the latest release version will be used. To make builds deterministic, we recommend pinning both the action version and the fappcli package version, e.g.:
+```yml
+- name: Install FApp CLI and login
+  uses: fixedit-ai/install-fappcli-action@v1
+  with:
+    token: ${{ secrets.FAPP_TOKEN }}
+    fappcli-version: "0.3.0"
+```

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ inputs:
     description: "The FixedIT access token"
     required: true
   fappcli-version:
-    description: "The version of fappcli to use"
+    description: "The version of fappcli to use (otherwise latest)"
     default: ""
 
 runs:
@@ -44,6 +44,6 @@ runs:
         ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
         CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain ${{ steps.token.outputs.py_domain }} --domain-owner $ACCOUNT_ID --region ${{ steps.token.outputs.region }} --query authorizationToken --output text)
         INDEX_URL="https://aws:$CODEARTIFACT_AUTH_TOKEN@${{ steps.token.outputs.py_domain }}-$ACCOUNT_ID.d.codeartifact.${{ steps.token.outputs.region }}.amazonaws.com/pypi/${{ steps.token.outputs.py_repository }}/simple/"
-        FAPPCLI_VERSION=`[[ -n "${{ inputs.fappcli-version }}" ]] && echo ${{ inputs.fappcli-version }} || echo 0.1.dev1+g8ede180`
-        pip install fappcli==$FAPPCLI_VERSION --extra-index-url=$INDEX_URL
+        FAPPCLI_PACKAGE=`[[ -n "${{ inputs.fappcli-version }}" ]] && echo fappcli==${{ inputs.fappcli-version }} || echo fappcli`
+        pip install $FAPPCLI_PACKAGE --extra-index-url=$INDEX_URL
         echo "{\"secrets\": {\"default\": \"${{ inputs.token }}\"}}" > ~/.fapp


### PR DESCRIPTION
Instead of pinning a specific fappcli version as default, we will default to the latest released version.